### PR TITLE
Allow encoding buffers, the same way as strings

### DIFF
--- a/src/janet-html.janet
+++ b/src/janet-html.janet
@@ -92,7 +92,8 @@
   [children]
   (or (indexed? children)
       (number? children)
-      (string? children)))
+      (string? children)
+      (buffer? children)))
 
 
 (defn- create-children


### PR DESCRIPTION
This allows, for example, to directly encode `slurp`ed data