### PR TITLE
Allow nil to be a root child element

### DIFF
--- a/src/janet-html.janet
+++ b/src/janet-html.janet
@@ -93,7 +93,8 @@
   (or (indexed? children)
       (number? children)
       (string? children)
-      (buffer? children)))
+      (buffer? children)
+      (nil? children)))
 
 
 (defn- create-children

--- a/test/janet-html.janet
+++ b/test/janet-html.janet
@@ -132,4 +132,8 @@
 
   (test "html/encode"
       (is (deep= "<!DOCTYPE HTML><li><a href=\"#\">Text</a>After Text</li>"
-                 (html/encode (html/doctype :html5) [:li [:a {:href "#"} "Text"] "After Text"])))))
+                 (html/encode (html/doctype :html5) [:li [:a {:href "#"} "Text"] "After Text"]))))
+
+  (test "html with nil children"
+    (= "<div>Home page</div>"
+       (html/html [[:div "Home page"] nil]))))


### PR DESCRIPTION
The library already handles nil during the creation process, but will error out during validation. 

I encountered this when creating a home page where some content was conditionally rendered if the user was logged in. Using `if` would naturally return `nil` when the condition was not met. A temporary solution was to have `[]` as the else result value but that did not bring me joy.