### PR TITLE
Add tests for `:<>` as an element name.

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -4,7 +4,8 @@
   :author "Brandon Chartier"
   :license "MIT"
   :url "https://github.com/brandonchartier/janet-html"
-  :repo "git+https://github.com/swlkr/janet-html")
+  :repo "git+https://github.com/swlkr/janet-html"
+  :dependencies ["https://github.com/joy-framework/tester"])
 
 (declare-source
   :source ["src/janet-html.janet"])

--- a/test/janet-html.janet
+++ b/test/janet-html.janet
@@ -42,6 +42,23 @@
                    [[:span "hello world"]
                     [:span "2"]]])))
 
+  (test "two non-nested elements without attributes"
+    (= `<span>hello world</span><span>2</span>`
+       (html/html [[:span "hello world"]
+                   [:span "2"]])))
+
+  (test "two non-nested elements without attributes - using :<> as a visual indicator for returning multiple elements"
+    (= `<span>hello world</span><span>2</span>`
+       (html/html [:<>
+                   [:span "hello world"]
+                   [:span "2"]])))
+
+  (test "two non-nested elements with attributes - using :<> as a visual indicator for returning multiple elements"
+    (= `<span class="my-greeting">hello world</span><span style="color: red;">2</span>`
+       (html/html [:<>
+                   [:span {:class "my-greeting"} "hello world"]
+                   [:span {:style "color: red;"} "2"]])))
+
   (test "non-empty div with attributes"
     (= `<div class="class">hello world</div>` (html/html [:div {:class "class"} "hello world"])))
 


### PR DESCRIPTION
Apparently you could already do the "multiple elements return" thing by just returning elements as an array. :sweat_smile: 

Still I think my previous PR has value as it's easier to spot `[:<> [.....]]` than `[[...]]` when reading code, so it serves as a nice visual indicator of what's going on.

So here's some tests. The existing tests still passed, so the previous PR didn't break anything.